### PR TITLE
add terminaltables benchmark

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -6,6 +6,7 @@ import tabulate
 import asciitable
 import prettytable
 import texttable
+import terminaltables
 import sys
 import codecs
 
@@ -19,6 +20,7 @@ import tabulate
 import asciitable
 import prettytable
 import texttable
+import terminaltables
 
 
 import platform
@@ -71,6 +73,8 @@ def run_tabulate(table, widechars=False):
     return tabulate.tabulate(table)
 
 
+def run_terminaltables(table):
+    return terminaltables.DoubleTable(table).table
 """
 
 methods = [(u"join with tabs and newlines", "join_table(table)"),
@@ -80,6 +84,7 @@ methods = [(u"join with tabs and newlines", "join_table(table)"),
            (u"tabulate (%s, WIDE_CHARS_MODE)" % tabulate.__version__, "run_tabulate(table, widechars=True)"),
            (u"PrettyTable (%s)" % prettytable.__version__, "run_prettytable(table)"),
            (u"texttable (%s)" % texttable.__version__, "run_texttable(table)"),
+           (u"terminaltables (%s)" % terminaltables.__version__, "run_terminaltables(table)"),
            ]
 
 


### PR DESCRIPTION
The result of this here looks like this:

```
===========================  ==========  ===========
Table formatter                time, μs    rel. time
===========================  ==========  ===========
csv to StringIO                    14.7          1.0
join with tabs and newlines        20.3          1.4
asciitable (0.8.0)                338.4         23.0
tabulate (0.8.3)                  725.3         49.3
terminaltables (3.1.0)            806.5         54.8
PrettyTable (0.7.2)              1364.5         92.7
texttable (1.6.2)                2044.0        138.8
===========================  ==========  ===========
```

ie. it is *very* close to tabulate's results in terms of performance,
although it doesn't have the flexibility of tabulate in terms of
output formats.